### PR TITLE
Add vision and payment sections, translation support

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": ".",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   }
 }

--- a/index.html
+++ b/index.html
@@ -6,52 +6,98 @@
   <title>mantoWallet</title>
   <style>
     body {
-      background: #111;
+      background: #000;
       color: gold;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0;
       text-align: center;
-      padding: 50px;
     }
-    .logo {
-      font-size: 3rem;
-      font-weight: bold;
+    header {
+      padding: 40px 20px;
+    }
+    .logo-img {
+      display: block;
+      margin: 0 auto;
+      max-width: 200px;
     }
     .btn {
       background: gold;
       color: #111;
       padding: 15px 30px;
-      font-size: 1.2rem;
+      font-size: 1rem;
       border: none;
       cursor: pointer;
-      margin-top: 30px;
       border-radius: 10px;
       transition: 0.3s ease;
+      display: inline-block;
+      margin: 15px;
     }
     .btn:hover {
       background: white;
     }
     #walletAddress {
-      margin-top: 20px;
       color: white;
-      font-size: 1rem;
+      margin-top: 10px;
+    }
+    .section {
+      padding: 60px 20px;
+    }
+    .vision {
+      background: #111;
+      color: gold;
+    }
+    .payments {
+      background: #222;
+      color: white;
+    }
+    .team {
+      background: #111;
+      color: white;
+    }
+    .team-member {
+      margin: 20px 0;
+    }
+    #google_translate_element {
+      margin-top: 10px;
+      color: white;
     }
   </style>
 </head>
 <body>
-  <div class="logo">⚡ mantoWallet</div>
-  <p>La Wallet Web3 del Reino – Conexión a Solana, diseño dorado, poderosa interfaz.</p>
-  <button class="btn" onclick="connectWallet()">Conectar Wallet Phantom</button>
-  <div id="walletAddress"></div>
+  <div id="google_translate_element">Traducir esta página</div>
+  <header>
+    <img src="assets/images/logo.png" alt="manto MT logo" class="logo-img">
+    <p>La Wallet Web3 del Reino – Conexión a Solana, diseño dorado y poderoso.</p>
+    <button class="btn" onclick="connectWallet()">Conectar Wallet Phantom</button>
+    <a class="btn" href="whitepaper.pdf" download>Descargar White Paper</a>
+    <div id="walletAddress"></div>
+  </header>
+
+  <section class="section vision">
+    <h2>Visión del Reino manto</h2>
+    <p>Plataforma espiritual y tecnológica uniendo reinos en un ecosistema de valor.</p>
+    <a class="btn" href="https://mantomineral.io" target="_blank">Respaldo Real – JGE-11221</a>
+    <a class="btn" href="https://whitepapermanto.com" target="_blank">White Paper manto</a>
+  </section>
+
+  <section class="section payments">
+    <h2>Pasarela de pagos híbrida</h2>
+    <p>Aceptamos tarjetas de crédito, USDC, Solana y manto MT.</p>
+  </section>
+
+  <section class="section team">
+    <h2>Equipo manto MT</h2>
+    <div class="team-member">Información del equipo no disponible.</div>
+  </section>
 
   <script>
     async function connectWallet() {
       try {
-        const provider = window?.phantom?.solana;
+        const provider = window.solana;
         if (!provider?.isPhantom) {
           alert('Phantom Wallet no está instalada.');
           return;
         }
-
         const resp = await provider.connect();
         document.getElementById('walletAddress').textContent = `Conectado a: ${resp.publicKey.toString()}`;
       } catch (err) {
@@ -60,5 +106,11 @@
       }
     }
   </script>
+  <script type="text/javascript">
+    function googleTranslateElementInit() {
+      new google.translate.TranslateElement({pageLanguage: 'es'}, 'google_translate_element');
+    }
+  </script>
+  <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- center official logo and add Google Translate option
- add golden White Paper button and vision section
- include real backing link and white paper link
- outline hybrid payment gateway section
- stub team area due to missing PDF

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68504a5cea0c832382ee1dde4ca5029c